### PR TITLE
Add missing QStringBuilder header

### DIFF
--- a/src/httpserver/qhttpserverrouterrule.cpp
+++ b/src/httpserver/qhttpserverrouterrule.cpp
@@ -37,6 +37,8 @@
 #include <QtCore/qregularexpression.h>
 #include <QtCore/qdebug.h>
 
+#include <QStringBuilder>
+
 QT_BEGIN_NAMESPACE
 
 Q_LOGGING_CATEGORY(lcRouterRule, "qt.httpserver.router.rule")


### PR DESCRIPTION
This fixes out-of-qt-source building under clang and maybe some other compilers

If using % for string concatenation - worth include QStringBuilder. Otherwise I got "error: invalid operands to binary expression ('QLatin1Char' and 'QString')" compilation error.

I am using clang 8.0.0 under Windows 10 64 bit with MSVC14 toolchain and CMake to build QtHttpServer just like separate project (not part of Qt) with Qt 5.12.0.