### PR TITLE
fix memory leak in `QHttpServerRequest`

### DIFF
--- a/src/httpserver/qhttpserverrequest.h
+++ b/src/httpserver/qhttpserverrequest.h
@@ -99,7 +99,7 @@ private:
 
     explicit QHttpServerRequest(const QHostAddress &remoteAddress);
 
-    QHttpServerRequestPrivate *d = nullptr;
+    QSharedDataPointer<QHttpServerRequestPrivate> d;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
Each request handling was leading to a memory leak of `sizeof(QHttpServerRequestPrivate)` octets