### PR TITLE
Fix ordering of sslserver to httpserver

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -2,10 +2,10 @@ TEMPLATE = subdirs
 
 QT = network
 
-SUBDIRS = \
-    httpserver
-
 qtConfig(ssl) {
     SUBDIRS += sslserver
     httpserver.depends = sslserver
 }
+
+SUBDIRS += \
+    httpserver


### PR DESCRIPTION
On a machine without this project installed in a QMAKEPATH, the
qmake-stage could fail: httpserver depends on sslserver (if ssl is
available), but qmake learned of sslserver only once that gets defined.

To fix this, just reorder the two targets in the src.pro file.