### PR TITLE
gitignore: add object_script.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ core
 Makefile*
 !/qmake/Makefile.win32*
 !/qmake/Makefile.unix
+object_script.*
 pcviewer.cfg
 tags
 *~


### PR DESCRIPTION
In my msys2 environment I get the files `src/httpserver/object_script.Qt5HttpServer.Release` and `src/httpserver/object_script.Qt5HttpServerd.Debug` during non-shadow builds.