### PR TITLE
correct 2 small bugs

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,3 +1,3 @@
 load(qt_build_config)
 
-MODULE_VERSION = 5.12.0
+MODULE_VERSION = 5.15.2

--- a/src/httpserver/qabstracthttpserver.cpp
+++ b/src/httpserver/qabstracthttpserver.cpp
@@ -88,7 +88,7 @@ void QAbstractHttpServerPrivate::handleReadyRead(QTcpSocket *socket,
         request->d->clear();
 
     if (!request->d->parse(socket)) {
-        socket->disconnect();
+        socket->disconnectFromHost();
         return;
     }
 

--- a/tests/auto/qhttpserver/tst_qhttpserver.cpp
+++ b/tests/auto/qhttpserver/tst_qhttpserver.cpp
@@ -349,12 +349,17 @@ void tst_QHttpServer::initTestCase()
             [expectedSslErrors](QNetworkReply *reply,
                                 const QList<QSslError> &errors) {
         for (const auto &error: errors) {
+            bool expected{false};
             for (const auto &expectedError: expectedSslErrors) {
-                if (error.error() != expectedError.error() ||
-                    error.certificate() != expectedError.certificate()) {
-                    qCritical() << "Got unexpected ssl error:"
-                                << error << error.certificate();
+                if (error.error() == expectedError.error() ||
+                    error.certificate() == expectedError.certificate()) {
+                    expected = true;
                 }
+            }
+            if(!expected)
+            {
+                qCritical() << "Got unexpected ssl error:"
+                            << error << error.certificate();
             }
         }
         reply->ignoreSslErrors(expectedSslErrors);


### PR DESCRIPTION
- SSL tests were failing due to qCritical abort in case of certificate error because the for loop expectation was never met by the 2 errors at the same time
- Http parse error disconnected the signal but did not closed the socket, leaving the client hanging (tested with curl to force a space in the query parameters). 
   Returning a 400 Bad Request could be good but I do not know the full implication that this change could have to the code flow.